### PR TITLE
Update paapi.py

### DIFF
--- a/amazon/paapi.py
+++ b/amazon/paapi.py
@@ -188,6 +188,7 @@ class AmazonAPI:
                     results = []
                     for item in response.items_result.items:
                         product = Product()
+                        product.item = item  # gives you pointer access to all data
                         product.asin = item.asin
 
                         try:


### PR DESCRIPTION
The current "parse only what's needed" approach leaves the developer completely unable to select additional keys which are available in the underlying data model. By pointing the product to the amz `item`, the developer has the ability to fetch whatever information is needed, which may not be available via the library's accessors.