### PR TITLE
Allow searching by browse_node or search_index alone

### DIFF
--- a/amazon/paapi.py
+++ b/amazon/paapi.py
@@ -234,10 +234,10 @@ class AmazonAPI:
             raise AmazonException('ValueError', 'Arg item_count should be between 1 and 100')
         if item_page < 1:
             raise AmazonException('ValueError', 'Arg item_page should be 1 or higher')
-        if not keywords and not actor and not artist and not author and not brand and not title:
+        if not keywords and not actor and not artist and not author and not brand and not title and not browse_node and not search_index:
             raise AmazonException('ValueError', 'At least one of the following args must be '
-                                                'provided: keywords, actor, artist, author, brand,'
-                                                'title')
+                                                'provided: keywords, actor, artist, author, brand, '
+                                                'title, browse_node, search_index')
         results = []
         while len(results) < item_count:
             try:


### PR DESCRIPTION


## Problem (Actual behavior)

In the latest version, v3.3.0, the following search requests raise `amazon.exception.AmazonException: ValueError: At least one of the following args must be provided: keywords, actor, artist, author, brand,title`.

```py
amazon.search_products(search_index='Books')
amazon.search_products(browse_node='2275256051')
```

## Expected behavior

The above requests should returns search results. Though [the API document](https://webservices.amazon.com/paapi5/documentation/search-items.html) is ambiguous, the SearchItems API returns expected results when we specify only `SearchIndex` or `BrowseNodeId` (at least in country JP).

In fact, requesting SearchItems without additional parameters in the Scratchpad, error message says as follows:

![image](https://user-images.githubusercontent.com/532251/88482358-aeeefd80-cf9b-11ea-8538-036af4af478f.png)

## Changes

This PR allows searching by `browse_node` or `search_index` alone.