### PR TITLE
Fix NameError in AmazonBrowseNode.to_str()

### DIFF
--- a/amazon/parse.py
+++ b/amazon/parse.py
@@ -1,5 +1,7 @@
 """Data parser for instance creation."""
+import pprint
 
+import six
 
 class Class:
     """Base class for creating the product instance."""
@@ -46,7 +48,7 @@ class AmazonBrowseNode():
                 ))
             else:
                 result[attr] = value
-        if issubclass(BrowseNode, dict):
+        if issubclass(AmazonBrowseNode, dict):
             for key, value in self.items():
                 result[key] = value
 
@@ -59,7 +61,7 @@ class AmazonBrowseNode():
         return self.to_str()
 
     def __eq__(self, other):
-        if not isinstance(other, BrowseNode):
+        if not isinstance(other, AmazonBrowseNode):
             return False
 
         return self.__dict__ == other.__dict__


### PR DESCRIPTION
In version 3.3.0, just printing browse nodes causes NameError. This PR fixes #34.

```py
browse_nodes = amazon.get_browsenodes(['466298'])
print(browse_nodes)
```

```
Traceback (most recent call last):
  File "browse_nodes.py", line 12, in <module>
    print(browse_nodes)
  File "/Users/**/venv/lib/python3.7/site-packages/amazon/parse.py", line 59, in __repr__
    return self.to_str()
  File "/Users/**/venv/lib/python3.7/site-packages/amazon/parse.py", line 56, in to_str
    return pprint.pformat(self.to_dict())
NameError: name 'pprint' is not defined
ERROR: exit status 1
```