### PR TITLE
Update get_asin

### DIFF
--- a/amazon/tools.py
+++ b/amazon/tools.py
@@ -16,7 +16,7 @@ def get_asin(url: str):
     if re.search(r'^[A-Z0-9]{10}$', url):
         return url
     # Extract ASIN from URL searching for alphanumeric and 10 digits
-    have_asin = re.search(r'(dp|gp/product|gp/aw/d)/([a-zA-Z0-9]{10})', url)
+    have_asin = re.search(r'(dp|gp/product|gp/aw/d|dp/product)/([a-zA-Z0-9]{10})', url)
     return have_asin.group(2) if have_asin else None
 
 


### PR DESCRIPTION
Just today I found out links like `https://www.amazon.it/Lapaginadeglisconti/dp/product/B079N83MSD/ref=ox_sc_act_title_1?smid=A11IL2PNWYJU7H&psc=1&tag=lapaginadell-test-21`

In this way, we are able to catch the ASIN too.