### PR TITLE
Update type hints such that APIItemInfo.product_info is optional to m…

### DIFF
--- a/amazon_paapi/models/item_result.py
+++ b/amazon_paapi/models/item_result.py
@@ -86,6 +86,7 @@ class ApiClassifications(models.Classifications):
 class ApiContentInfo(models.ContentInfo):
     edition: ApiSingleStringValuedAttribute
     languages: ApiMultiValuedAttributeType
+    publication_date: ApiSingleStringValuedAttribute
 
 
 class ApiContentRating(models.ContentRating):

--- a/amazon_paapi/models/item_result.py
+++ b/amazon_paapi/models/item_result.py
@@ -86,7 +86,7 @@ class ApiClassifications(models.Classifications):
 class ApiContentInfo(models.ContentInfo):
     edition: ApiSingleStringValuedAttribute
     languages: ApiMultiValuedAttributeType
-    publication_date: ApiSingleStringValuedAttribute
+    publication_date: Optional[ApiSingleStringValuedAttribute]
 
 
 class ApiContentRating(models.ContentRating):

--- a/amazon_paapi/models/item_result.py
+++ b/amazon_paapi/models/item_result.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from ..sdk import models
 
@@ -148,7 +148,7 @@ class ApiItemInfo(models.ItemInfo):
     external_ids: ApiExternalIds
     features: ApiFeatures
     manufacture_info: ApiManufactureInfo
-    product_info: ApiProductInfo
+    product_info: Optional[ApiProductInfo]
     technical_info: ApiTechnicalInfo
     title: ApiSingleStringValuedAttribute
     trade_in_info: ApiTradeInInfo


### PR DESCRIPTION
…atch Amazon responses.

Thank you for maintaining this repo!

I've found that in my code `item_info.product_info` is often `None`. The issue is that if I try to access something like `...item_info.product_info.release_date` (e.g., for a movie), MyPy doesn't warn me that I need to make sure that `item_info.product_info` is not None, which it frequently is.

This PR makes `product_info` optional which should allow MyPy to flag code that doesn't check for a None type item_info.product_info.