### PR TITLE
Make item_info.content_info optional per some Amazon API responses.

### DIFF
--- a/amazon_paapi/models/item_result.py
+++ b/amazon_paapi/models/item_result.py
@@ -144,7 +144,7 @@ class ApiTradeInInfo(models.TradeInInfo):
 class ApiItemInfo(models.ItemInfo):
     by_line_info: ApiByLineInfo
     classifications: ApiClassifications
-    content_info: ApiContentInfo
+    content_info: Optional[ApiContentInfo]
     content_rating: ApiContentRating
     external_ids: ApiExternalIds
     features: ApiFeatures


### PR DESCRIPTION
@sergioteula thanks for merging/deploying the previous; just had this error pop up in my logs as well.