### PR TITLE
Add robustness to failure of python multiprocessing

### DIFF
--- a/amazon_paapi/sdk/api_client.py
+++ b/amazon_paapi/sdk/api_client.py
@@ -88,9 +88,12 @@ class ApiClient(object):
             configuration = Configuration()
         self.configuration = configuration
 
-        self.pool = ThreadPool()
-        self.rest_client = rest.RESTClientObject(configuration)
-        self.default_headers = {}
+        try:
+            self.pool = ThreadPool()
+        except:
+            # if multiprocessing is not available, we can't use the pool        self.rest_client = rest.RESTClientObject(configuration)
+            self.default_headers = {}
+
         if header_name is not None:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
@@ -103,8 +106,9 @@ class ApiClient(object):
         self.region = region
 
     def __del__(self):
-        self.pool.close()
-        self.pool.join()
+        if self.pool is not None:
+            self.pool.close()
+            self.pool.join()
 
     @property
     def user_agent(self):

--- a/amazon_paapi/sdk/api_client.py
+++ b/amazon_paapi/sdk/api_client.py
@@ -91,9 +91,11 @@ class ApiClient(object):
         try:
             self.pool = ThreadPool()
         except:
-            # if multiprocessing is not available, we can't use the pool        self.rest_client = rest.RESTClientObject(configuration)
-            self.default_headers = {}
+            # if multiprocessing is not available, we can't use the pool
+            self.pool = None
 
+        self.rest_client = rest.RESTClientObject(configuration)
+        self.default_headers = {}
         if header_name is not None:
             self.default_headers[header_name] = header_value
         self.cookie = cookie


### PR DESCRIPTION
Add robustness to failure of the Python standard multiprocessing module.  This can happen for processes running in an ```suexec``` environment on a commercial cloud server where files in ```/sys``` are not readable, and leads to very unhelpful error messages and deep tracebacks.

The changes mean that if a thread pool can't be created then carry on in a single-threaded way.