### PR TITLE
feat: add configurable request timeout to the Creators API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [7.1.0] - 2026-09-03
+
+### Added
+
+- `timeout` parameter in `AmazonCreatorsApi` and `AsyncAmazonCreatorsApi` to set the request timeout in seconds, or `None` to wait indefinitely
+
+### Changed
+
+- `AmazonCreatorsApi` API requests now time out after 30 seconds instead of waiting indefinitely, matching the timeout already used by `AsyncAmazonCreatorsApi`. Pass `timeout=None` to restore the previous behavior
+- `AsyncAmazonCreatorsApi` now applies `timeout` to the OAuth2 token refresh as well, which previously always used the 5 second default from `httpx`
+
 ## [7.0.0] - 2026-09-03
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -140,6 +140,17 @@ amazon = AmazonCreatorsApi(ID, SECRET, VERSION, TAG, COUNTRY, throttling=4)  # M
 amazon = AmazonCreatorsApi(ID, SECRET, VERSION, TAG, COUNTRY, throttling=0)  # No wait time between requests
 ```
 
+### Timeout
+
+Timeout value represents the number of seconds to wait for a response before failing, being the default value 30 seconds. Use `None` to wait indefinitely.
+
+```python
+amazon = AmazonCreatorsApi(ID, SECRET, VERSION, TAG, COUNTRY, timeout=10)  # Fails after 10 seconds
+amazon = AmazonCreatorsApi(ID, SECRET, VERSION, TAG, COUNTRY, timeout=0.5)  # Fails after half a second
+```
+
+It applies to every API request. In `AmazonCreatorsApi` the OAuth2 token refresh is handled by the bundled SDK and is not covered by this value, while `AsyncAmazonCreatorsApi` applies it to the token refresh as well.
+
 ### Async Support
 
 For async/await applications, use the async version of the API with `httpx`:

--- a/amazon_creatorsapi/aio/api.py
+++ b/amazon_creatorsapi/aio/api.py
@@ -12,11 +12,14 @@ from typing import TYPE_CHECKING, Any, TypeVar
 
 from typing_extensions import Self
 
-from amazon_creatorsapi.core.constants import DEFAULT_THROTTLING
+from amazon_creatorsapi.core.constants import DEFAULT_THROTTLING, DEFAULT_TIMEOUT
 from amazon_creatorsapi.core.error_handling import handle_api_error
 from amazon_creatorsapi.core.parsers import get_asin, get_items_ids
 from amazon_creatorsapi.core.resources import get_all_resources
-from amazon_creatorsapi.core.validation import validate_and_get_marketplace
+from amazon_creatorsapi.core.validation import (
+    validate_and_get_marketplace,
+    validate_timeout,
+)
 from amazon_creatorsapi.errors import ItemsNotFoundError
 
 try:
@@ -118,9 +121,12 @@ class AsyncAmazonCreatorsApi:
         country: Country code (e.g., "ES", "US"). Used to determine marketplace.
         marketplace: Marketplace URL (e.g., "www.amazon.es"). Overrides country.
         throttling: Wait time in seconds between API calls. Defaults to 1 second.
+        timeout: Request timeout in seconds, or None to wait indefinitely.
+            Defaults to 30 seconds.
 
     Raises:
-        InvalidArgumentError: If neither country nor marketplace is provided.
+        InvalidArgumentError: If neither country nor marketplace is provided,
+            or if timeout is not greater than zero.
         ValueError: If version is not supported (valid versions: 2.1, 2.2, 2.3,
             3.1, 3.2, 3.3).
 
@@ -135,6 +141,7 @@ class AsyncAmazonCreatorsApi:
         country: CountryCode | None = None,
         marketplace: str | None = None,
         throttling: float = DEFAULT_THROTTLING,
+        timeout: float | None = DEFAULT_TIMEOUT,
     ) -> None:
         """Initialize the async Amazon Creators API client."""
         # Validate version early to fail fast (before token manager initialization)
@@ -147,6 +154,7 @@ class AsyncAmazonCreatorsApi:
         self._throttle_lock: asyncio.Lock | None = None
         self.tag = tag
         self.throttling = float(throttling)
+        self.timeout = validate_timeout(timeout)
 
         # Determine marketplace from country or direct value
         self.marketplace = validate_and_get_marketplace(country, marketplace)
@@ -157,6 +165,7 @@ class AsyncAmazonCreatorsApi:
             credential_id=credential_id,
             credential_secret=credential_secret,
             version=version,
+            timeout=self.timeout,
         )
         self._owns_client = False
 
@@ -177,7 +186,7 @@ class AsyncAmazonCreatorsApi:
 
     async def __aenter__(self) -> Self:
         """Enter async context manager, creating a persistent HTTP client."""
-        self._http_client = AsyncHttpClient(host=API_HOST)
+        self._http_client = AsyncHttpClient(host=API_HOST, timeout=self.timeout)
         await self._http_client.__aenter__()
         self._owns_client = True
         return self
@@ -596,7 +605,7 @@ class AsyncAmazonCreatorsApi:
         if self._http_client is not None:
             response = await self._http_client.post(endpoint, headers, body)
         else:
-            async with AsyncHttpClient(host=API_HOST) as client:
+            async with AsyncHttpClient(host=API_HOST, timeout=self.timeout) as client:
                 response = await client.post(endpoint, headers, body)
 
         # Handle errors

--- a/amazon_creatorsapi/aio/auth.py
+++ b/amazon_creatorsapi/aio/auth.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import time
 
+from amazon_creatorsapi.core.constants import DEFAULT_TIMEOUT
 from amazon_creatorsapi.errors import AuthenticationError
 
 try:
@@ -55,6 +56,8 @@ class AsyncOAuth2TokenManager:
         credential_secret: OAuth2 credential secret.
         version: API version (determines auth endpoint).
         auth_endpoint: Optional custom auth endpoint URL.
+        timeout: Token request timeout in seconds, or None to wait
+            indefinitely. Defaults to 30 seconds.
 
     """
 
@@ -64,12 +67,14 @@ class AsyncOAuth2TokenManager:
         credential_secret: str,
         version: str,
         auth_endpoint: str | None = None,
+        timeout: float | None = DEFAULT_TIMEOUT,
     ) -> None:
         """Initialize the async OAuth2 token manager."""
         self._credential_id = credential_id
         self._credential_secret = credential_secret
         self._version = version
         self._auth_endpoint = self._determine_auth_endpoint(version, auth_endpoint)
+        self._timeout = timeout
 
         self._access_token: str | None = None
         self._expires_at: float | None = None
@@ -186,7 +191,7 @@ class AsyncOAuth2TokenManager:
         }
 
         try:
-            async with httpx.AsyncClient() as client:
+            async with httpx.AsyncClient(timeout=self._timeout) as client:
                 if self.is_lwa():
                     response = await client.post(
                         self._auth_endpoint,

--- a/amazon_creatorsapi/aio/client.py
+++ b/amazon_creatorsapi/aio/client.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING, Any
 
 from typing_extensions import Self
 
+from amazon_creatorsapi.core.constants import DEFAULT_TIMEOUT
+
 if TYPE_CHECKING:
     from types import TracebackType
 
@@ -26,7 +28,6 @@ except ImportError as exc:  # pragma: no cover
 
 
 DEFAULT_HOST = "https://creatorsapi.amazon"
-DEFAULT_TIMEOUT = 30.0
 VERSION = version("python-amazon-paapi")
 USER_AGENT = f"python-amazon-paapi/{VERSION} (async)"
 
@@ -64,14 +65,15 @@ class AsyncHttpClient:
 
     Args:
         host: Base URL for API requests. Defaults to Amazon Creators API.
-        timeout: Request timeout in seconds. Defaults to 30.
+        timeout: Request timeout in seconds, or None to wait indefinitely.
+            Defaults to 30.
 
     """
 
     def __init__(
         self,
         host: str = DEFAULT_HOST,
-        timeout: float = DEFAULT_TIMEOUT,
+        timeout: float | None = DEFAULT_TIMEOUT,
     ) -> None:
         """Initialize the async HTTP client."""
         self._host = host

--- a/amazon_creatorsapi/api.py
+++ b/amazon_creatorsapi/api.py
@@ -8,11 +8,14 @@ from __future__ import annotations
 import time
 from typing import TYPE_CHECKING, NoReturn
 
-from amazon_creatorsapi.core.constants import DEFAULT_THROTTLING
+from amazon_creatorsapi.core.constants import DEFAULT_THROTTLING, DEFAULT_TIMEOUT
 from amazon_creatorsapi.core.error_handling import handle_api_error
 from amazon_creatorsapi.core.parsers import get_asin, get_items_ids
 from amazon_creatorsapi.core.resources import get_all_resources
-from amazon_creatorsapi.core.validation import validate_and_get_marketplace
+from amazon_creatorsapi.core.validation import (
+    validate_and_get_marketplace,
+    validate_timeout,
+)
 from amazon_creatorsapi.errors import ItemsNotFoundError
 from creatorsapi_python_sdk.api.default_api import DefaultApi
 from creatorsapi_python_sdk.api_client import ApiClient
@@ -68,9 +71,12 @@ class AmazonCreatorsApi:
         country: Country code (e.g., "ES", "US"). Used to determine marketplace.
         marketplace: Marketplace URL (e.g., "www.amazon.es"). Overrides country.
         throttling: Wait time in seconds between API calls. Defaults to 1 second.
+        timeout: Request timeout in seconds, or None to wait indefinitely.
+            Defaults to 30 seconds.
 
     Raises:
-        InvalidArgumentError: If neither country nor marketplace is provided.
+        InvalidArgumentError: If neither country nor marketplace is provided,
+            or if timeout is not greater than zero.
 
     Example:
         >>> api = AmazonCreatorsApi(
@@ -93,6 +99,7 @@ class AmazonCreatorsApi:
         country: CountryCode | None = None,
         marketplace: str | None = None,
         throttling: float = DEFAULT_THROTTLING,
+        timeout: float | None = DEFAULT_TIMEOUT,
     ) -> None:
         """Initialize the Amazon Creators API client."""
         self._credential_id = credential_id
@@ -101,6 +108,7 @@ class AmazonCreatorsApi:
         self._last_query_time = time.time() - throttling
         self.tag = tag
         self.throttling = float(throttling)
+        self.timeout = validate_timeout(timeout)
 
         # Determine marketplace from country or direct value
         self.marketplace = validate_and_get_marketplace(country, marketplace)
@@ -158,6 +166,7 @@ class AmazonCreatorsApi:
             response = self._api.get_items(
                 x_marketplace=self.marketplace,
                 get_items_request_content=request,
+                _request_timeout=self.timeout,
             )
         except ApiException as exc:
             self._handle_api_exception(exc)
@@ -258,6 +267,7 @@ class AmazonCreatorsApi:
             response = self._api.search_items(
                 x_marketplace=self.marketplace,
                 search_items_request_content=request,
+                _request_timeout=self.timeout,
             )
         except ApiException as exc:
             self._handle_api_exception(exc)
@@ -318,6 +328,7 @@ class AmazonCreatorsApi:
             response = self._api.get_variations(
                 x_marketplace=self.marketplace,
                 get_variations_request_content=request,
+                _request_timeout=self.timeout,
             )
         except ApiException as exc:
             self._handle_api_exception(exc)
@@ -364,6 +375,7 @@ class AmazonCreatorsApi:
             response = self._api.get_browse_nodes(
                 x_marketplace=self.marketplace,
                 get_browse_nodes_request_content=request,
+                _request_timeout=self.timeout,
             )
         except ApiException as exc:
             self._handle_api_exception(exc)
@@ -392,7 +404,10 @@ class AmazonCreatorsApi:
         self._throttle()
 
         try:
-            response = self._api.list_feeds(x_marketplace=self.marketplace)
+            response = self._api.list_feeds(
+                x_marketplace=self.marketplace,
+                _request_timeout=self.timeout,
+            )
         except ApiException as exc:
             self._handle_api_exception(exc)
 
@@ -421,6 +436,7 @@ class AmazonCreatorsApi:
             response = self._api.get_feed(
                 x_marketplace=self.marketplace,
                 get_feed_request_content=request,
+                _request_timeout=self.timeout,
             )
         except ApiException as exc:
             self._handle_api_exception(exc)
@@ -442,7 +458,10 @@ class AmazonCreatorsApi:
         self._throttle()
 
         try:
-            response = self._api.list_reports(x_marketplace=self.marketplace)
+            response = self._api.list_reports(
+                x_marketplace=self.marketplace,
+                _request_timeout=self.timeout,
+            )
         except ApiException as exc:
             self._handle_api_exception(exc)
 
@@ -471,6 +490,7 @@ class AmazonCreatorsApi:
             response = self._api.get_report(
                 x_marketplace=self.marketplace,
                 get_report_request_content=request,
+                _request_timeout=self.timeout,
             )
         except ApiException as exc:
             self._handle_api_exception(exc)

--- a/amazon_creatorsapi/core/constants.py
+++ b/amazon_creatorsapi/core/constants.py
@@ -1,6 +1,7 @@
 """Constants for the Amazon Creators API."""
 
 DEFAULT_THROTTLING = 1
+DEFAULT_TIMEOUT = 30.0
 
 # HTTP status codes
 HTTP_NOT_FOUND = 404

--- a/amazon_creatorsapi/core/validation.py
+++ b/amazon_creatorsapi/core/validation.py
@@ -38,3 +38,24 @@ def validate_and_get_marketplace(
         return MARKETPLACES[country]
     msg = "Either 'country' or 'marketplace' must be provided"
     raise InvalidArgumentError(msg)
+
+
+def validate_timeout(timeout: float | None) -> float | None:
+    """Validate the request timeout value.
+
+    Args:
+        timeout: Request timeout in seconds, or None to wait indefinitely.
+
+    Returns:
+        The timeout as a float, or None when disabled.
+
+    Raises:
+        InvalidArgumentError: If the timeout is not greater than zero.
+
+    """
+    if timeout is None:
+        return None
+    if timeout <= 0:
+        msg = "Timeout must be greater than zero, or None to wait indefinitely"
+        raise InvalidArgumentError(msg)
+    return float(timeout)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ copyright = "2026, Sergio Abad"
 author = "Sergio Abad"
 
 # The full version, including alpha/beta/rc tags
-release = "7.0.0"
+release = "7.1.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/pages/usage-guide.md
+++ b/docs/pages/usage-guide.md
@@ -121,6 +121,17 @@ api = AmazonCreatorsApi(ID, SECRET, VERSION, TAG, COUNTRY, throttling=4)  # Make
 api = AmazonCreatorsApi(ID, SECRET, VERSION, TAG, COUNTRY, throttling=0)  # No wait time between requests
 ```
 
+## Timeout
+
+Timeout value represents the number of seconds to wait for a response before failing, being the default value 30 seconds. Use `None` to wait indefinitely.
+
+```python
+api = AmazonCreatorsApi(ID, SECRET, VERSION, TAG, COUNTRY, timeout=10)  # Fails after 10 seconds
+api = AmazonCreatorsApi(ID, SECRET, VERSION, TAG, COUNTRY, timeout=0.5)  # Fails after half a second
+```
+
+It applies to every API request. In `AmazonCreatorsApi` the OAuth2 token refresh is handled by the bundled SDK and is not covered by this value, while `AsyncAmazonCreatorsApi` applies it to the token refresh as well.
+
 ## Async Support
 
 For async/await applications, install with async support:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-amazon-paapi"
-version = "7.0.0"
+version = "7.1.0"
 description = "Amazon Creators API wrapper for Python"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/amazon_creatorsapi/aio/api_test.py
+++ b/tests/amazon_creatorsapi/aio/api_test.py
@@ -6,6 +6,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from amazon_creatorsapi.aio import (
     AsyncAmazonCreatorsApi,
 )
+from amazon_creatorsapi.aio.api import API_HOST
+from amazon_creatorsapi.core.constants import DEFAULT_TIMEOUT
 from amazon_creatorsapi.errors import (
     AssociateValidationError,
     InvalidArgumentError,
@@ -70,6 +72,77 @@ class TestAsyncAmazonCreatorsApiInit(unittest.TestCase):
         )
 
         self.assertEqual(api.throttling, 2.5)
+
+    @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
+    def test_with_default_timeout(self, mock_token_manager: MagicMock) -> None:
+        """Test initialization uses the default timeout value."""
+        api = AsyncAmazonCreatorsApi(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            tag="test-tag",
+            country="US",
+        )
+
+        self.assertEqual(api.timeout, DEFAULT_TIMEOUT)
+
+    @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
+    def test_with_custom_timeout(self, mock_token_manager: MagicMock) -> None:
+        """Test initialization with custom timeout value."""
+        api = AsyncAmazonCreatorsApi(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            tag="test-tag",
+            country="US",
+            timeout=5.0,
+        )
+
+        self.assertEqual(api.timeout, 5.0)
+
+    @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
+    def test_with_timeout_disabled(self, mock_token_manager: MagicMock) -> None:
+        """Test initialization keeps a None timeout to wait indefinitely."""
+        api = AsyncAmazonCreatorsApi(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            tag="test-tag",
+            country="US",
+            timeout=None,
+        )
+
+        self.assertIsNone(api.timeout)
+
+    @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
+    def test_with_invalid_timeout(self, mock_token_manager: MagicMock) -> None:
+        """Test initialization rejects a timeout that is not above zero."""
+        for timeout in (0, -1.5):
+            with self.assertRaises(InvalidArgumentError):
+                AsyncAmazonCreatorsApi(
+                    credential_id="test_id",
+                    credential_secret="test_secret",
+                    version="2.2",
+                    tag="test-tag",
+                    country="US",
+                    timeout=timeout,
+                )
+
+    @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
+    def test_timeout_passed_to_token_manager(
+        self, mock_token_manager: MagicMock
+    ) -> None:
+        """Test the token manager gets the timeout used for API requests."""
+        AsyncAmazonCreatorsApi(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            tag="test-tag",
+            country="US",
+            timeout=5.0,
+        )
+
+        self.assertEqual(mock_token_manager.call_args.kwargs["timeout"], 5.0)
 
     @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
     def test_accepts_lwa_version(self, mock_token_manager: MagicMock) -> None:
@@ -1597,6 +1670,115 @@ class TestAsyncAmazonCreatorsApiReports(unittest.IsolatedAsyncioTestCase):
             {"filename": "earnings.csv", "reportType": "CREATOR_CENTRAL"},
             mock_client.post.call_args.args[2],
         )
+
+
+class TestAsyncAmazonCreatorsApiTimeout(unittest.IsolatedAsyncioTestCase):
+    """Tests for the timeout given to the underlying HTTP client."""
+
+    @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
+    @patch("amazon_creatorsapi.aio.api.AsyncHttpClient")
+    async def test_context_manager_client_uses_default_timeout(
+        self,
+        mock_http_client_class: MagicMock,
+        mock_token_manager: MagicMock,
+    ) -> None:
+        """Test the persistent client is created with the default timeout."""
+        mock_http_client_class.return_value = AsyncMock()
+
+        async with AsyncAmazonCreatorsApi(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            tag="test-tag",
+            country="ES",
+        ):
+            pass
+
+        mock_http_client_class.assert_called_once_with(
+            host=API_HOST,
+            timeout=DEFAULT_TIMEOUT,
+        )
+
+    @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
+    @patch("amazon_creatorsapi.aio.api.AsyncHttpClient")
+    async def test_context_manager_client_uses_custom_timeout(
+        self,
+        mock_http_client_class: MagicMock,
+        mock_token_manager: MagicMock,
+    ) -> None:
+        """Test the persistent client is created with a custom timeout."""
+        mock_http_client_class.return_value = AsyncMock()
+
+        async with AsyncAmazonCreatorsApi(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            tag="test-tag",
+            country="ES",
+            timeout=5.0,
+        ):
+            pass
+
+        mock_http_client_class.assert_called_once_with(host=API_HOST, timeout=5.0)
+
+    @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
+    @patch("amazon_creatorsapi.aio.api.AsyncHttpClient")
+    async def test_request_without_context_manager_uses_custom_timeout(
+        self,
+        mock_http_client_class: MagicMock,
+        mock_token_manager_class: MagicMock,
+    ) -> None:
+        """Test the temporary client is created with a custom timeout."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "itemsResult": {"items": [{"ASIN": "B0DLFMFBJW"}]}
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_http_client_class.return_value = mock_client
+
+        mock_token_manager = AsyncMock()
+        mock_token_manager.get_token.return_value = "test_token"
+        mock_token_manager_class.return_value = mock_token_manager
+
+        api = AsyncAmazonCreatorsApi(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            tag="test-tag",
+            country="ES",
+            throttling=0,
+            timeout=5.0,
+        )
+
+        await api.get_items(["B0DLFMFBJW"])
+
+        mock_http_client_class.assert_called_once_with(host=API_HOST, timeout=5.0)
+
+    @patch("amazon_creatorsapi.aio.api.AsyncOAuth2TokenManager")
+    @patch("amazon_creatorsapi.aio.api.AsyncHttpClient")
+    async def test_client_receives_disabled_timeout(
+        self,
+        mock_http_client_class: MagicMock,
+        mock_token_manager: MagicMock,
+    ) -> None:
+        """Test a None timeout is passed to the HTTP client to disable it."""
+        mock_http_client_class.return_value = AsyncMock()
+
+        async with AsyncAmazonCreatorsApi(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            tag="test-tag",
+            country="ES",
+            timeout=None,
+        ):
+            pass
+
+        mock_http_client_class.assert_called_once_with(host=API_HOST, timeout=None)
 
 
 if __name__ == "__main__":

--- a/tests/amazon_creatorsapi/aio/auth_test.py
+++ b/tests/amazon_creatorsapi/aio/auth_test.py
@@ -14,6 +14,7 @@ from amazon_creatorsapi.aio.auth import (
     VERSION_ENDPOINTS,
     AsyncOAuth2TokenManager,
 )
+from amazon_creatorsapi.core.constants import DEFAULT_TIMEOUT
 from amazon_creatorsapi.errors import AuthenticationError
 
 
@@ -351,6 +352,68 @@ class TestAsyncOAuth2TokenManagerRefreshToken(unittest.IsolatedAsyncioTestCase):
             await manager.refresh_token()
 
         self.assertIn("token request failed", str(context.exception))
+
+
+class TestAsyncOAuth2TokenManagerTimeout(unittest.IsolatedAsyncioTestCase):
+    """Tests for the timeout applied to token refresh requests."""
+
+    def _mock_client(self, mock_client_class: MagicMock) -> None:
+        """Wire the httpx client mock to return a valid token response."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "access_token": "test_token",
+            "expires_in": 3600,
+        }
+
+        mock_client = AsyncMock()
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__.return_value = mock_client
+        mock_client_class.return_value = mock_client
+
+    def test_default_timeout(self) -> None:
+        """Test the manager keeps the default timeout."""
+        manager = AsyncOAuth2TokenManager(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+        )
+
+        self.assertEqual(manager._timeout, DEFAULT_TIMEOUT)
+
+    @patch("amazon_creatorsapi.aio.auth.httpx.AsyncClient")
+    async def test_refresh_token_uses_custom_timeout(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        """Test token refresh creates the client with the given timeout."""
+        self._mock_client(mock_client_class)
+        manager = AsyncOAuth2TokenManager(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            timeout=5.0,
+        )
+
+        await manager.refresh_token()
+
+        mock_client_class.assert_called_once_with(timeout=5.0)
+
+    @patch("amazon_creatorsapi.aio.auth.httpx.AsyncClient")
+    async def test_refresh_token_with_timeout_disabled(
+        self, mock_client_class: MagicMock
+    ) -> None:
+        """Test token refresh can wait indefinitely when the timeout is None."""
+        self._mock_client(mock_client_class)
+        manager = AsyncOAuth2TokenManager(
+            credential_id="test_id",
+            credential_secret="test_secret",
+            version="2.2",
+            timeout=None,
+        )
+
+        await manager.refresh_token()
+
+        mock_client_class.assert_called_once_with(timeout=None)
 
 
 if __name__ == "__main__":

--- a/tests/amazon_creatorsapi/aio/client_test.py
+++ b/tests/amazon_creatorsapi/aio/client_test.py
@@ -32,6 +32,11 @@ class TestAsyncHttpClient(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(client._host, host)
         self.assertEqual(client._timeout, timeout)
 
+    async def test_init_timeout_disabled(self) -> None:
+        """Test the timeout can be disabled with None."""
+        client = AsyncHttpClient(timeout=None)
+        self.assertIsNone(client._timeout)
+
     @patch("amazon_creatorsapi.aio.client.httpx.AsyncClient")
     async def test_context_manager(self, mock_client_cls: MagicMock) -> None:
         """Test context manager creates and closes client."""

--- a/tests/amazon_creatorsapi/api_test.py
+++ b/tests/amazon_creatorsapi/api_test.py
@@ -9,6 +9,7 @@ from unittest import mock
 from unittest.mock import MagicMock
 
 from amazon_creatorsapi import AmazonCreatorsApi
+from amazon_creatorsapi.core.constants import DEFAULT_TIMEOUT
 from amazon_creatorsapi.errors import (
     AssociateValidationError,
     InvalidArgumentError,
@@ -859,7 +860,10 @@ class TestAmazonCreatorsApi(unittest.TestCase):
         result = self._build_api().list_feeds()
 
         self.assertEqual([feed], result)
-        mock_api.list_feeds.assert_called_once_with(x_marketplace="www.amazon.es")
+        mock_api.list_feeds.assert_called_once_with(
+            x_marketplace="www.amazon.es",
+            _request_timeout=DEFAULT_TIMEOUT,
+        )
 
     @mock.patch("amazon_creatorsapi.api.DefaultApi")
     @mock.patch("amazon_creatorsapi.api.ApiClient")
@@ -957,7 +961,10 @@ class TestAmazonCreatorsApi(unittest.TestCase):
         result = self._build_api().list_reports()
 
         self.assertEqual([report], result)
-        mock_api.list_reports.assert_called_once_with(x_marketplace="www.amazon.es")
+        mock_api.list_reports.assert_called_once_with(
+            x_marketplace="www.amazon.es",
+            _request_timeout=DEFAULT_TIMEOUT,
+        )
 
     @mock.patch("amazon_creatorsapi.api.DefaultApi")
     @mock.patch("amazon_creatorsapi.api.ApiClient")
@@ -1027,3 +1034,227 @@ class TestAmazonCreatorsApi(unittest.TestCase):
 
         with self.assertRaises(RequestError):
             self._build_api().get_report("report.csv")
+
+    @mock.patch("amazon_creatorsapi.api.ApiClient")
+    def test_init_with_invalid_timeout(self, _mock_client: MagicMock) -> None:
+        """Test that a timeout of zero or below is rejected."""
+        for timeout in (0, -1.5):
+            with self.assertRaises(InvalidArgumentError):
+                AmazonCreatorsApi(
+                    credential_id=self.credential_id,
+                    credential_secret=self.credential_secret,
+                    version=self.version,
+                    tag=self.tag,
+                    country=self.country,
+                    timeout=timeout,
+                )
+
+    @mock.patch("amazon_creatorsapi.api.DefaultApi")
+    @mock.patch("amazon_creatorsapi.api.ApiClient")
+    def test_get_items_uses_default_timeout(
+        self,
+        _mock_client_class: MagicMock,
+        mock_api_class: MagicMock,
+    ) -> None:
+        """Test get_items forwards the default timeout to the SDK."""
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_response = MagicMock()
+        mock_response.items_result.items = [MagicMock()]
+        mock_api.get_items.return_value = mock_response
+
+        api = AmazonCreatorsApi(
+            credential_id=self.credential_id,
+            credential_secret=self.credential_secret,
+            version=self.version,
+            tag=self.tag,
+            country=self.country,
+            throttling=0,
+        )
+        api.get_items(["B0DLFMFBJW"])
+
+        self.assertEqual(api.timeout, DEFAULT_TIMEOUT)
+        self.assertEqual(
+            mock_api.get_items.call_args.kwargs["_request_timeout"],
+            DEFAULT_TIMEOUT,
+        )
+
+    @mock.patch("amazon_creatorsapi.api.DefaultApi")
+    @mock.patch("amazon_creatorsapi.api.ApiClient")
+    def test_get_items_forwards_custom_timeout(
+        self,
+        _mock_client_class: MagicMock,
+        mock_api_class: MagicMock,
+    ) -> None:
+        """Test get_items forwards a custom timeout to the SDK."""
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_response = MagicMock()
+        mock_response.items_result.items = [MagicMock()]
+        mock_api.get_items.return_value = mock_response
+
+        api = AmazonCreatorsApi(
+            credential_id=self.credential_id,
+            credential_secret=self.credential_secret,
+            version=self.version,
+            tag=self.tag,
+            country=self.country,
+            throttling=0,
+            timeout=15.0,
+        )
+        api.get_items(["B0DLFMFBJW"])
+
+        self.assertEqual(
+            mock_api.get_items.call_args.kwargs["_request_timeout"],
+            15.0,
+        )
+
+    @mock.patch("amazon_creatorsapi.api.DefaultApi")
+    @mock.patch("amazon_creatorsapi.api.ApiClient")
+    def test_get_items_with_timeout_disabled(
+        self,
+        _mock_client_class: MagicMock,
+        mock_api_class: MagicMock,
+    ) -> None:
+        """Test get_items sends no timeout to the SDK when it is disabled."""
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_response = MagicMock()
+        mock_response.items_result.items = [MagicMock()]
+        mock_api.get_items.return_value = mock_response
+
+        api = AmazonCreatorsApi(
+            credential_id=self.credential_id,
+            credential_secret=self.credential_secret,
+            version=self.version,
+            tag=self.tag,
+            country=self.country,
+            throttling=0,
+            timeout=None,
+        )
+        api.get_items(["B0DLFMFBJW"])
+
+        self.assertIsNone(mock_api.get_items.call_args.kwargs["_request_timeout"])
+
+    @mock.patch("amazon_creatorsapi.api.DefaultApi")
+    @mock.patch("amazon_creatorsapi.api.ApiClient")
+    def test_search_items_forwards_custom_timeout(
+        self,
+        _mock_client_class: MagicMock,
+        mock_api_class: MagicMock,
+    ) -> None:
+        """Test search_items forwards a custom timeout to the SDK."""
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_response = MagicMock()
+        mock_response.search_result = MagicMock()
+        mock_api.search_items.return_value = mock_response
+
+        api = AmazonCreatorsApi(
+            credential_id=self.credential_id,
+            credential_secret=self.credential_secret,
+            version=self.version,
+            tag=self.tag,
+            country=self.country,
+            throttling=0,
+            timeout=5.0,
+        )
+        api.search_items(keywords="laptop")
+
+        self.assertEqual(
+            mock_api.search_items.call_args.kwargs["_request_timeout"],
+            5.0,
+        )
+
+    @mock.patch("amazon_creatorsapi.api.DefaultApi")
+    @mock.patch("amazon_creatorsapi.api.ApiClient")
+    def test_get_variations_forwards_custom_timeout(
+        self,
+        _mock_client_class: MagicMock,
+        mock_api_class: MagicMock,
+    ) -> None:
+        """Test get_variations forwards a custom timeout to the SDK."""
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_response = MagicMock()
+        mock_response.variations_result = MagicMock()
+        mock_api.get_variations.return_value = mock_response
+
+        api = AmazonCreatorsApi(
+            credential_id=self.credential_id,
+            credential_secret=self.credential_secret,
+            version=self.version,
+            tag=self.tag,
+            country=self.country,
+            throttling=0,
+            timeout=3.5,
+        )
+        api.get_variations("B0DLFMFBJW")
+
+        self.assertEqual(
+            mock_api.get_variations.call_args.kwargs["_request_timeout"],
+            3.5,
+        )
+
+    @mock.patch("amazon_creatorsapi.api.DefaultApi")
+    @mock.patch("amazon_creatorsapi.api.ApiClient")
+    def test_get_browse_nodes_forwards_custom_timeout(
+        self,
+        _mock_client_class: MagicMock,
+        mock_api_class: MagicMock,
+    ) -> None:
+        """Test get_browse_nodes forwards a custom timeout to the SDK."""
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+        mock_response = MagicMock()
+        mock_response.browse_nodes_result.browse_nodes = [MagicMock()]
+        mock_api.get_browse_nodes.return_value = mock_response
+
+        api = AmazonCreatorsApi(
+            credential_id=self.credential_id,
+            credential_secret=self.credential_secret,
+            version=self.version,
+            tag=self.tag,
+            country=self.country,
+            throttling=0,
+            timeout=7.5,
+        )
+        api.get_browse_nodes(["123456"])
+
+        self.assertEqual(
+            mock_api.get_browse_nodes.call_args.kwargs["_request_timeout"],
+            7.5,
+        )
+
+    @mock.patch("amazon_creatorsapi.api.DefaultApi")
+    @mock.patch("amazon_creatorsapi.api.ApiClient")
+    def test_feed_and_report_methods_forward_timeout(
+        self,
+        _mock_client_class: MagicMock,
+        mock_api_class: MagicMock,
+    ) -> None:
+        """Test feed and report methods forward the timeout to the SDK."""
+        mock_api = MagicMock()
+        mock_api_class.return_value = mock_api
+
+        api = AmazonCreatorsApi(
+            credential_id=self.credential_id,
+            credential_secret=self.credential_secret,
+            version=self.version,
+            tag=self.tag,
+            country=self.country,
+            throttling=0,
+            timeout=9.0,
+        )
+        api.list_feeds()
+        api.get_feed("feed.csv")
+        api.list_reports()
+        api.get_report("report.csv")
+
+        for call in (
+            mock_api.list_feeds,
+            mock_api.get_feed,
+            mock_api.list_reports,
+            mock_api.get_report,
+        ):
+            self.assertEqual(call.call_args.kwargs["_request_timeout"], 9.0)


### PR DESCRIPTION
Supersedes #151. Same feature, rebased onto `master` (7.0.0) and with the points raised while reviewing that PR applied. Original work by @YPCrumble, authorship preserved on the commit.

## What it does

Adds a `timeout` parameter to `AmazonCreatorsApi` and `AsyncAmazonCreatorsApi`, defaulting to 30 seconds, with `None` to wait indefinitely. The sync client previously had no timeout at all, so a stalled connection to Amazon could hold a worker forever; it now matches what the async client already did.

## Changes over #151

- **Rebased onto 7.0.0** and renumbered to **7.1.0** (`pyproject.toml`, `docs/conf.py`, `CHANGELOG.md`). The original branch targeted 6.4.0, which conflicted after the 6.4.0 and 7.0.0 releases.
- **Feeds and reports covered too.** `list_feeds`, `get_feed`, `list_reports` and `get_report` landed after the original branch was written and were not forwarding `_request_timeout`, so the timeout applied to only half the methods.
- **Async token refresh honours the timeout.** `AsyncOAuth2TokenManager` built its `httpx.AsyncClient` with no arguments, so token refresh always used the 5 second httpx default regardless of the configured value. It now takes the same timeout as the API requests.
- **Zero and negative timeouts are rejected** with `InvalidArgumentError` at construction. Previously they reached the bundled SDK, where `_request_timeout` is annotated `gt=0`, and surfaced as a raw pydantic `ValidationError` in the sync client while failing instantly in the async one.
- **Wording corrected.** The original changelog entry claimed requests would no longer wait indefinitely; that is true for API requests but not for the sync OAuth2 token refresh, which `creatorsapi_python_sdk` performs with a bare `requests.post` and no timeout. The entry now says "API requests", and the README and usage guide state what the value does and does not cover.

## Known limitation

The sync token refresh remains unbounded. Fixing it means either patching the bundled SDK, which the repo otherwise keeps untouched, or giving the sync client its own token manager the way `amazon_creatorsapi.aio` already has. Left out of this PR deliberately — happy to follow up whichever way you prefer.

## Verification

`uv run pre-commit run -a` passes in full: ruff format, ruff check, mypy, the test suite and the version consistency check. 160 passed, 47 skipped (integration tests, no credentials), coverage 98.76% against the 98% floor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JvKfVvJqdCZnPfNaNP2fT5

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvKfVvJqdCZnPfNaNP2fT5)_