### PR TITLE
Release version 7.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [7.0.0] - 2026-09-04
 
 ### Added
 
+- `list_feeds`, `get_feed`, `list_reports` and `get_report` methods in `amazon_creatorsapi` and `amazon_creatorsapi.aio`, with `Feed`, `FeedType`, `ReportMetadata` and `ReportType` in `amazon_creatorsapi.models` and in the bundled SDK
+- `timeout` parameter in `AmazonCreatorsApi` and `AsyncAmazonCreatorsApi` to set the request timeout in seconds, or `None` to wait indefinitely
+- `retries` parameter in `AmazonCreatorsApi` and `AsyncAmazonCreatorsApi` to retry the throttled and failed requests that Amazon asks to retry, waiting longer before every attempt and honouring the `Retry-After` header, whether Amazon sends it as an amount of seconds or as a date
+- `include_unavailable` parameter in `get_items` to get an item holding only the ASIN for every requested item missing from the response
+- `availability` parameter in `search_items` to include the items that are out of stock, keyword only and placed after the rest, so the arguments of a caller not using keywords keep their position
+- `host` and `auth_endpoint` parameters in `AmazonCreatorsApi` and `AsyncAmazonCreatorsApi` to replace the endpoints of the API, useful to run tests against a mock server or to use a version newer than the ones known by the library, as long as the library can authenticate its family
+- `AccessDeniedError`, raised when the credentials cannot perform the requested operation
+- `ResourceNotFoundError`, raised when a feed or report does not exist, telling it apart from missing items
+- Partial errors of a response are available in the `errors` attribute of the lists returned by `get_items` and `get_browse_nodes`, and are reported in the message of `ItemsNotFoundError`
+- `ErrorData` and `ResultList` available in `amazon_creatorsapi.models`
+- `get_asin` and `errors` are available directly in `amazon_creatorsapi`
+- The identifier that Amazon gives to a request is part of the message of the error, so it can be reported to Amazon support
+- `close` method and context manager support in `AmazonCreatorsApi`, to release the connections of a client that is not going to be reused
+- `py.typed` marker, so the type hints of the package are used by type checkers
 - Migration guide from version 6, listing what can break in code written for `amazon_creatorsapi` and how to fix it
 - The values accepted by `version`, the countries and the marketplace each one maps to, and the `marketplace` argument are documented, instead of having to read the code to find them
 - `CONTRIBUTING.md`, with the setup of the project, the commands of the `Makefile`, the conventions of the code and the tests, and what a pull request is expected to carry
@@ -16,139 +30,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `availability` is a keyword only argument of `search_items`, placed after the rest, instead of sitting between `item_page` and `condition`, where it displaced every following argument of a caller not using keywords
+- Requests time out after 30 seconds instead of waiting indefinitely, the refresh of the token included, which waited indefinitely in `AmazonCreatorsApi` and used the 5 second default of `httpx` in `AsyncAmazonCreatorsApi`. Pass `timeout=None` to restore the previous behaviour
+- Errors are mapped from the response of the Creators API instead of the codes of the old Product Advertising API, so the reason and the fields that failed are part of the message
+- A rejected request raises `InvalidArgumentError`, missing or expired credentials raise `AuthenticationError` and a forbidden request raises `AccessDeniedError`, instead of a generic `RequestError`
+- Values rejected by the API constraints raise `InvalidArgumentError` instead of a `pydantic.ValidationError`
+- Connection failures and unparseable responses raise `RequestError` instead of leaking the errors of the HTTP client
+- An expired token is refreshed once and the request is sent again instead of failing
 - `AuthenticationError` and `AccessDeniedError` are subclasses of `RequestError`, which is what a failed request raised before they got their own type
 - `InvalidArgumentError` is also a `ValueError`, as the `pydantic.ValidationError` and the plain `ValueError` it replaced were
-- An unsupported `version` raises `InvalidArgumentError` instead of a plain `ValueError`, like the rest of the arguments of the clients
-- A `version` of a family that the library cannot authenticate is rejected even when `auth_endpoint` is given, instead of being sent with the Cognito flow and rejected by Amazon without an explanation
-- The error of an unsupported version tells that a newer version of a known family can be used by providing its `auth_endpoint`
-- The auth flow of a version and the `Authorization` header it expects are decided in a single place, and the copies bundled in the SDK are pinned to them by tests, so a bump of the SDK cannot leave both halves disagreeing
-- The usage guide covers everything the README does, so the documentation does not have to be read in both places, and the README links to it
-- The integration tests reach every operation of the API, feeds and reports included, and both clients share the same assertions, so a difference between them is a failure instead of a gap
-- Every integration test reads the results of a single round of calls, which loads each request with as much as it can check, so the whole API is covered without spending more requests of the account
-- The async integration tests make their calls when the suite runs instead of when the module is imported, so they are not sent when the tests are deselected and a failure is reported as such
-
-### Fixed
-
-- The migration guide listed `include_unavailable`, `availability` and `delivery_flags` as removed by the Creators API, which accepts the three of them
-- The migration guide imported `get_asin` from `amazon_creatorsapi.core` and did not list `AuthenticationError`, `AccessDeniedError` and `ResourceNotFoundError` among the exceptions of the module
-- Documentation that promised the same methods in both clients without telling that `close` only exists in the synchronous one, as every request of an asynchronous client used outside `async with` closes its own connection
-
-## [7.4.0] - 2026-09-04
-
-### Added
-
-- `availability` parameter in `search_items` to include the items that are out of stock
-- `host` and `auth_endpoint` parameters in `AmazonCreatorsApi` and `AsyncAmazonCreatorsApi` to replace the endpoints of the API, useful to run tests against a mock server
-- `get_asin` and `errors` are available directly in `amazon_creatorsapi`
-- The identifier that Amazon gives to a request is part of the message of the error, so it can be reported to Amazon support
-- `py.typed` marker, so the type hints of the package are used by type checkers
-- `close` method and context manager support in `AmazonCreatorsApi`, to release the connections of a client that is not going to be reused
-
-### Changed
-
+- `get_items` splits a request with more items than the API accepts into as many calls as needed, so any amount of items can be requested at once
+- `get_items` returns the items in the order they were requested, and asks for duplicated items only once
+- `get_items` raises `ItemsNotFoundError` when the response holds no requested item, as documented, instead of returning an empty list
 - `search_items` rejects a search without any criteria instead of sending it to the API
+- An unsupported `version` raises `InvalidArgumentError` instead of a plain `ValueError`, like the rest of the arguments of the clients, and a version of a family that the library cannot authenticate is rejected even when `auth_endpoint` is given, instead of being sent with the Cognito flow and rejected by Amazon without an explanation
+- The error of an unsupported version tells that a newer version of a known family can be used by providing its `auth_endpoint`
+- `AmazonCreatorsApi` validates the version when it is created, as `AsyncAmazonCreatorsApi` already did, instead of failing on the first request
+- The auth flow of a version and the `Authorization` header it expects are decided in a single place shared by both clients, and the copies bundled in the SDK are pinned to them by tests, so a bump of the SDK cannot leave both halves disagreeing
 - `AsyncAmazonCreatorsApi` builds its requests with the models of the SDK, so both clients validate the same values before sending a request
 - Every client uses its own configuration for the SDK instead of the one shared by the whole process
 - Throttling is measured with a monotonic clock and is safe to use from several threads
 - `throttling` is validated like the rest of the options, so a negative or invalid value raises `InvalidArgumentError` instead of being accepted or failing with a `TypeError`
-- `Retry-After` is also honoured when Amazon sends it as a date instead of an amount of seconds
-- Both clients resolve the auth endpoint with the same list of versions, so a new version only has to be added once
+- The usage guide covers everything the README does, so the documentation does not have to be read in both places, and the README links to it
+- The integration tests reach every operation of the API, feeds and reports included, and both clients share the same assertions, so a difference between them is a failure instead of a gap
+- Every integration test reads the results of a single round of calls, which loads each request with as much as it can check, so the whole API is covered without spending more requests of the account
+- The async integration tests make their calls when the suite runs instead of when the module is imported, so they are not sent when the tests are deselected and a failure is reported as such
+- The CI workflow runs the test suite once per Python version instead of also running it inside the linter job, cancels superseded pull request runs and installs `uv` through a cached action
+- The release workflow builds with `uv build`, and its check for an already existing tag looks for the tag name that is actually created, which never matched before
+- Bumped the bundled `creatorsapi-python-sdk` from `1.2.0` to `1.3.0`, which makes `partnerTag` a required field of `SearchItemsRequestContent`
+- Pinned `ruff` to the version run by pre-commit, so `make lint` matches CI
 
 ### Fixed
 
 - Examples in the documentation that used names that do not exist, such as `SortBy.PRICE_LOW_TO_HIGH` or `GetItemsResource.ITEMINFO_TITLE`
 - Documented limits of `item_count`, `min_reviews_rating` and `variation_page`, which did not match the ones accepted by the API
-- `auth_endpoint` is enough to use a version that the library does not know about in `AsyncAmazonCreatorsApi`, which rejected it even with a custom endpoint
 - A token response that does not hold JSON raises `AuthenticationError` in `AsyncAmazonCreatorsApi`, instead of the error of the JSON parser
 - Errors reported by the transport, such as an invalid certificate, keep their reason instead of being reported as `Request failed with status 0`
 - An ASIN longer than ten characters in a URL is rejected instead of being trimmed to a different item
-- `get_items` raises `ItemsNotFoundError` when the response holds no requested item, instead of returning an empty list
 - Threads sharing a client ask for a single token when the cached one expires, instead of one for every thread
+- Search integration tests no longer assume Amazon always returns a full page of items
 
 ### Removed
 
-- `six` dependency, which was not used
-
-## [7.3.0] - 2026-09-03
-
-### Added
-
-- `retries` parameter in `AmazonCreatorsApi` and `AsyncAmazonCreatorsApi` to retry the throttled and failed requests that Amazon asks to retry, waiting longer before every attempt and honouring the `Retry-After` header
-- `AccessDeniedError`, raised when the credentials cannot perform the requested operation
-- `ResourceNotFoundError`, raised when a feed or report does not exist, telling it apart from missing items
-
-### Changed
-
-- Errors are mapped from the response of the Creators API instead of the codes of the old Product Advertising API, so the reason and the fields that failed are part of the message
-- A rejected request raises `InvalidArgumentError`, missing or expired credentials raise `AuthenticationError` and a forbidden request raises `AccessDeniedError`, instead of a generic `RequestError`
-- An expired token is refreshed once and the request is sent again instead of failing
-- Connection failures and unparseable responses raise `RequestError` instead of leaking the errors of the HTTP client
-
-## [7.2.0] - 2026-09-03
-
-### Added
-
-- `get_items` splits a request with more items than the API accepts into as many calls as needed, so any amount of items can be requested at once
-- `include_unavailable` parameter in `get_items` to get an item holding only the ASIN for every requested item missing from the response
-- Partial errors of a response are available in the `errors` attribute of the lists returned by `get_items` and `get_browse_nodes`, and are reported in the message of `ItemsNotFoundError`
-- `ErrorData` and `ResultList` available in `amazon_creatorsapi.models`
-
-### Changed
-
-- `get_items` returns the items in the order they were requested, and asks for duplicated items only once
-- `AmazonCreatorsApi` applies the timeout to the OAuth2 token refresh as well, which previously waited indefinitely, and reports its failures as `AuthenticationError`
-- `AmazonCreatorsApi` validates the version when it is created, as `AsyncAmazonCreatorsApi` already did, instead of failing on the first request
-- Values rejected by the API constraints raise `InvalidArgumentError` instead of a `pydantic.ValidationError`
-- `get_items` raises `ItemsNotFoundError` when the response holds no items, as documented, instead of returning an empty list
-
-## [7.1.0] - 2026-09-03
-
-### Added
-
-- `timeout` parameter in `AmazonCreatorsApi` and `AsyncAmazonCreatorsApi` to set the request timeout in seconds, or `None` to wait indefinitely
-
-### Changed
-
-- `AmazonCreatorsApi` API requests now time out after 30 seconds instead of waiting indefinitely, matching the timeout already used by `AsyncAmazonCreatorsApi`. Pass `timeout=None` to restore the previous behavior
-- `AsyncAmazonCreatorsApi` now applies `timeout` to the OAuth2 token refresh as well, which previously always used the 5 second default from `httpx`
-- The CI workflow now runs the test suite once per Python version instead of also running it inside the linter job, cancels superseded pull request runs and installs `uv` through a cached action
-- The release workflow now builds with `uv build`, and its check for an already existing tag now looks for the tag name that is actually created, which never matched before
-
-## [7.0.0] - 2026-09-03
-
-### Removed
-
-- The deprecated `amazon_paapi` module and its bundled Product Advertising API 5.0 SDK
-- `AmazonApi`, `amazon_paapi.errors`, `amazon_paapi.helpers`, `amazon_paapi.models` and `amazon_paapi.tools`
+- The deprecated `amazon_paapi` module and its bundled Product Advertising API 5.0 SDK, with `AmazonApi`, `amazon_paapi.errors`, `amazon_paapi.helpers`, `amazon_paapi.models` and `amazon_paapi.tools`. Use `amazon_creatorsapi` instead, following the [migration guide](https://python-amazon-paapi.readthedocs.io/en/latest/pages/migration-guide-6.html) for the credential, method and exception mapping
 - Product Advertising API documentation and deprecation notices in the README and docs
 - `API_KEY` and `API_SECRET` environment variables, only used by the removed module
-
-### Changed
-
-- Use `amazon_creatorsapi` instead. See the
-  [migration guide](https://python-amazon-paapi.readthedocs.io/en/latest/pages/migration-guide-6.html)
-  for the credential, method and exception mapping
-
-## [6.4.0] - 2026-09-03
-
-### Added
-
-- `list_feeds`, `get_feed`, `list_reports` and `get_report` methods in `amazon_creatorsapi` and `amazon_creatorsapi.aio`
-- `Feed`, `FeedType`, `ReportMetadata` and `ReportType` in `amazon_creatorsapi.models`
-- `FeedType` and `ReportType` models in the bundled SDK
-- `feedType` field in `Feed` and `GetFeedRequestContent` models
-- `reportType` field in `ReportMetadata` and `GetReportRequestContent` models
-
-### Changed
-
-- Bumped `creatorsapi-python-sdk` from `1.2.0` to `1.3.0`
-- `partnerTag` is now a required field in `SearchItemsRequestContent`
-- Pinned `ruff` to the version run by pre-commit, so `make lint` matches CI
-
-### Fixed
-
-- Search integration tests no longer assume Amazon always returns a full page of items
+- `six` dependency, which was not used
 
 ## [6.3.0] - 2026-05-15
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ copyright = "2026, Sergio Abad"
 author = "Sergio Abad"
 
 # The full version, including alpha/beta/rc tags
-release = "7.4.0"
+release = "7.0.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "python-amazon-paapi"
-version = "7.4.0"
+version = "7.0.0"
 description = "Amazon Creators API wrapper for Python"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary
This release consolidates multiple feature releases (7.1.0 through 7.4.0) into a single 7.0.0 release, reorganizing the changelog to reflect all changes in one version entry.

## Changes
The changelog has been restructured to consolidate all previously separate minor releases into version 7.0.0, including:

- **New API Methods**: `list_feeds`, `get_feed`, `list_reports`, and `get_report` methods with corresponding models (`Feed`, `FeedType`, `ReportMetadata`, `ReportType`)
- **Timeout & Retry Support**: Added `timeout` parameter (30-second default) and `retries` parameter with exponential backoff and `Retry-After` header support
- **Enhanced Error Handling**: New exception types (`AccessDeniedError`, `ResourceNotFoundError`) with improved error messages including Amazon request identifiers
- **Improved `get_items`**: Automatic request splitting for large item counts, `include_unavailable` parameter, and proper error handling with `ItemsNotFoundError`
- **Configuration Options**: `host` and `auth_endpoint` parameters for custom endpoints, useful for testing and newer API versions
- **Resource Management**: Added `close()` method and context manager support for `AmazonCreatorsApi`
- **Type Safety**: Added `py.typed` marker for better type checker support
- **Documentation**: Migration guide, contribution guidelines, and comprehensive test coverage including feeds and reports
- **Validation Improvements**: Version validation at client creation time, better argument validation with `InvalidArgumentError`
- **SDK Bump**: Updated bundled `creatorsapi-python-sdk` from 1.2.0 to 1.3.0
- **Removed**: Deprecated `amazon_paapi` module and `six` dependency

## Version Updates
- Updated version in `pyproject.toml` from 7.4.0 to 7.0.0
- Updated release version in `docs/conf.py` from 7.4.0 to 7.0.0

https://claude.ai/code/session_01Hkr63PESsV3gfpyC8rGWM2